### PR TITLE
Replace obsolete URI.escape with CGI.unescape

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rake'
 
 group :test do
   gem 'rspec', '>= 2.11'
-  gem 'simplecov', :require => false
+  gem 'rubocop'
+  gem 'simplecov', require: false
   gem 'webmock'
 end
-
 
 # Specify your gem's dependencies in screenshot_machine.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
-task :test => :spec
-task :default => :spec
+task test: :spec
+task default: :spec

--- a/lib/screenshot_machine.rb
+++ b/lib/screenshot_machine.rb
@@ -1,13 +1,15 @@
-require "uri"
-require "open-uri"
-require "screenshot_machine/version"
-require "screenshot_machine/configuration"
+# frozen_string_literal: true
+
+require 'uri'
+require 'open-uri'
+require 'screenshot_machine/version'
+require 'screenshot_machine/configuration'
 
 module ScreenshotMachine
   extend Configuration
 
-  API_URL = "http://api.screenshotmachine.com/"
-  
+  API_URL = 'http://api.screenshotmachine.com/'
+
   module Exceptions
     class InvalidUrl < StandardError; end
     class InvalidKey < StandardError; end
@@ -19,13 +21,14 @@ module ScreenshotMachine
     # Alias for ScreenshotMachine::Generator.new
     #
     # @return [ScreenshotMachine::Generator]
-    def new(url, options={})
+    def new(url, options = {})
       ScreenshotMachine::Generator.new(url, options)
     end
 
     # Delegate to ScreenshotMachine::Generator
     def method_missing(method, *args, &block)
       return super unless new.respond_to?(method)
+
       new.send(method, *args, &block)
     end
 
@@ -36,4 +39,4 @@ module ScreenshotMachine
   end
 end
 
-require "screenshot_machine/generator"
+require 'screenshot_machine/generator'

--- a/lib/screenshot_machine/configuration.rb
+++ b/lib/screenshot_machine/configuration.rb
@@ -1,19 +1,22 @@
+# frozen_string_literal: true
+
 module ScreenshotMachine
   module Configuration
     # An array of valid keys in the options hash when configuring TweetStream.
-    VALID_PARAMS_KEYS = [
-      :size,
-      :format,
-      :cacheLimit,
-      :timeout,
-      :url,
-      :key].freeze
+    VALID_PARAMS_KEYS = %i[
+      size
+      format
+      cacheLimit
+      timeout
+      url
+      key
+    ].freeze
 
-     # @private
-    attr_accessor *VALID_PARAMS_KEYS
+    # @private
+    attr_accessor(*VALID_PARAMS_KEYS)
 
-    DEFAULT_SIZE        = "L"     # T, S, E, N, M, L, X, F
-    DEFAULT_FORMAT      = "JPG"   # JPG, GIF, PNG
+    DEFAULT_SIZE        = 'L'     # T, S, E, N, M, L, X, F
+    DEFAULT_FORMAT      = 'JPG'   # JPG, GIF, PNG
     DEFAULT_CACHELIMIT  = 14      # 0-14 in days
     DEFAULT_TIMEOUT     = 200     # 0, 200, 400, 600, 800, 1000 in ms
     DEFAULT_URL         = nil
@@ -31,15 +34,15 @@ module ScreenshotMachine
 
     # Create a hash of options and their values
     def options
-      Hash[*VALID_PARAMS_KEYS.map {|key| [key, send(key)] }.flatten]
+      Hash[*VALID_PARAMS_KEYS.map { |key| [key, send(key)] }.flatten]
     end
 
     # Reset all configuration options to defaults
     def reset
       self.size       = DEFAULT_SIZE
       self.format     = DEFAULT_FORMAT
-      self.cacheLimit = DEFAULT_CACHELIMIT      
-      self.timeout    = DEFAULT_TIMEOUT     
+      self.cacheLimit = DEFAULT_CACHELIMIT
+      self.timeout    = DEFAULT_TIMEOUT
       self.url        = DEFAULT_URL
       self.key        = DEFAULT_KEY
       self

--- a/lib/screenshot_machine/generator.rb
+++ b/lib/screenshot_machine/generator.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 module ScreenshotMachine
   class Generator
-    
-    attr_accessor *Configuration::VALID_PARAMS_KEYS
-    
-    def initialize(url, options={})
-      merged_options = ScreenshotMachine.options.
-        merge({ :url => url }).
-        merge(options)
+    attr_accessor(*Configuration::VALID_PARAMS_KEYS)
+
+    def initialize(url, options = {})
+      merged_options = ScreenshotMachine.options
+                                        .merge({ url: url })
+                                        .merge(options)
       Configuration::VALID_PARAMS_KEYS.each do |key|
         send("#{key}=", merged_options[key])
       end
@@ -14,16 +15,16 @@ module ScreenshotMachine
 
     def screenshot
       @screenshot ||= begin
-        response = open(screenshot_url)
-        case response.meta["x-screenshotmachine-response"]
-        when "invalid_url"
-          raise Exceptions::InvalidUrl, "WARNING: Invalid URL"
-        when "invalid_key"
-          raise Exceptions::InvalidKey, "ERROR: Invalid API KEY"
-        when "no_credits"
-          raise Exceptions::NoCredits,  "ERROR: No Credits for API"
-        when "system_error"
-          raise Exceptions::SystemError,  "ERROR: API System Error"
+        response = URI.parse(screenshot_url).open
+        case response.meta['x-screenshotmachine-response']
+        when 'invalid_url'
+          raise Exceptions::InvalidUrl, 'WARNING: Invalid URL'
+        when 'invalid_key'
+          raise Exceptions::InvalidKey, 'ERROR: Invalid API KEY'
+        when 'no_credits'
+          raise Exceptions::NoCredits,  'ERROR: No Credits for API'
+        when 'system_error'
+          raise Exceptions::SystemError, 'ERROR: API System Error'
         end
         response.read
       end
@@ -31,14 +32,15 @@ module ScreenshotMachine
 
     private
 
-      def params
-        Hash[*Configuration::VALID_PARAMS_KEYS.map {|key| [key, send(key)] }.flatten]
-      end
+    def params
+      Hash[*Configuration::VALID_PARAMS_KEYS.map { |key| [key, send(key)] }.flatten]
+    end
 
-      def screenshot_url
-        uri = URI.parse(API_URL)
-        uri.query = URI.escape(params.map{|k,v| "#{k}=#{v}"}.join('&'))
-        uri.to_s
-      end
+    def screenshot_url
+      uri = URI.parse(API_URL)
+      query = CGI.unescape(params.map { |k, v| "#{k}=#{v}" }.join('&'))
+      uri.query = query
+      uri.to_s
+    end
   end
 end

--- a/lib/screenshot_machine/version.rb
+++ b/lib/screenshot_machine/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScreenshotMachine
-  VERSION = "0.0.4"
+  VERSION = '0.0.5'
 end

--- a/screenshot_machine.gemspec
+++ b/screenshot_machine.gemspec
@@ -1,17 +1,19 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/screenshot_machine/version', __FILE__)
+# frozen_string_literal: true
+
+require 'English'
+require File.expand_path('lib/screenshot_machine/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Constantin Hofstetter"]
-  gem.email         = ["consti@consti.de"]
-  gem.description   = %q{Screenshot Machine Gem}
-  gem.summary       = %q{This gem returns a screenshot of a webpage, using the ScreenshotMachine.com API (free account required).}
-  gem.homepage      = ""
+  gem.authors       = ['Constantin Hofstetter']
+  gem.email         = ['consti@consti.de']
+  gem.description   = 'Screenshot Machine Gem'
+  gem.summary       = 'This gem returns a screenshot of a webpage, using the ScreenshotMachine.com API (free account required).'
+  gem.homepage      = ''
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "screenshot_machine"
-  gem.require_paths = ["lib"]
+  gem.name          = 'screenshot_machine'
+  gem.require_paths = ['lib']
   gem.version       = ScreenshotMachine::VERSION
 end

--- a/spec/screenshot_machine/generator_spec.rb
+++ b/spec/screenshot_machine/generator_spec.rb
@@ -1,104 +1,114 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe ScreenshotMachine::Generator do
-  describe ".new" do
-    it "requires one argument" do
+RSpec.describe ScreenshotMachine::Generator do
+  describe '.new' do
+    it 'requires one argument' do
       expect { ScreenshotMachine::Generator.new }.to raise_error(ArgumentError)
       expect(ScreenshotMachine::Generator).to respond_to(:new).with(1).argument
     end
 
-    it "takes an optional second argument" do
+    it 'takes an optional second argument' do
       expect(ScreenshotMachine::Generator).to respond_to(:new).with(2).arguments
     end
 
-    it "initializes with one argument" do
+    it 'initializes with one argument' do
       generator = ScreenshotMachine::Generator.new(true)
       expect(generator).to be_kind_of(ScreenshotMachine::Generator)
     end
 
-    it "takes the url as first argument" do
+    it 'takes the url as first argument' do
       url = 'http://example.com'
       generator = ScreenshotMachine::Generator.new(url)
       expect(generator.url).to eq(url)
     end
 
-    it "takes the options as second argument" do
+    it 'takes the options as second argument' do
       url       = nil
-      options   = { :key => 'abc123' }
+      options   = { key: 'abc123' }
       generator = ScreenshotMachine::Generator.new(url, options)
       expect(generator.key).to eq(options[:key])
     end
   end
 
-  describe ".screenshot_url" do
-    let(:generator){ ScreenshotMachine::Generator.new("http://example.com") }
+  describe '.screenshot_url' do
+    let(:generator) { ScreenshotMachine::Generator.new('http://example.com') }
 
-    it "calls params" do
-      generator.should_receive(:params).and_return( { :a => 'b', :c => 'd' })
+    it 'calls params' do
+      generator.should_receive(:params).and_return({ a: 'b', c: 'd' })
       generator.send(:screenshot_url)
     end
 
-    it "includes all params" do
-      generator.should_receive(:params).and_return( { :a => 'b', :c => 'd' })
-      expect(generator.send(:screenshot_url)).to match("a=b")
+    it 'includes all params' do
+      generator.should_receive(:params).and_return({ a: 'b', c: 'd' })
+      expect(generator.send(:screenshot_url)).to match('a=b')
     end
 
-    it "includes the API_URL" do
+    it 'includes the API_URL' do
       expect(generator.send(:screenshot_url)).to match(ScreenshotMachine::API_URL)
     end
   end
 
-  describe ".screenshot" do
-    let(:generator){ ScreenshotMachine::Generator.new("http://example.com") }
+  describe '.screenshot' do
+    before do
+      stub_request(:get, /api\.screenshotmachine\.com.*/)
+        .to_return(
+          status: 200,
+          headers: { 'x-screenshotmachine-response' => 'invalid_url' }
+        )
+    end
 
-    context "when a valid API call" do
-      it "returns a string" do
+    let(:generator) { ScreenshotMachine::Generator.new('http://example.com') }
+
+    context 'when a valid API call' do
+      it 'returns a string' do
         stub_request(:get, /api\.screenshotmachine\.com.*/)
         expect(generator.screenshot.class).to eq(String)
       end
     end
 
-    context "when requesting an invalid URL" do
-      it "should raise an exception" do
-        stub_request(:get, /api\.screenshotmachine\.com.*/).
-          to_return(
-            :status => 200,  
-            :headers => { 'x-screenshotmachine-response' => 'invalid_url' } 
+    context 'when requesting an invalid URL' do
+      it 'should raise an exception' do
+        stub_request(:get, /api\.screenshotmachine\.com.*/)
+          .to_return(
+            status: 200,
+            headers: { 'x-screenshotmachine-response' => 'invalid_url' }
           )
-        expect{ generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::InvalidUrl)
+        expect { generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::InvalidUrl)
       end
     end
 
-    context "when requesting an invalid API KEY" do
-      it "should raise an exception" do
-        stub_request(:get, /api\.screenshotmachine\.com.*/).
-          to_return(
-            :status => 200,  
-            :headers => { 'x-screenshotmachine-response' => 'invalid_key' } 
+    context 'when requesting an invalid API KEY' do
+      it 'should raise an exception' do
+        stub_request(:get, /api\.screenshotmachine\.com.*/)
+          .to_return(
+            status: 200,
+            headers: { 'x-screenshotmachine-response' => 'invalid_key' }
           )
-        expect{ generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::InvalidKey)
+        expect { generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::InvalidKey)
       end
     end
 
-    context "when requesting with no credits left" do
-      it "should raise an exception" do
-        stub_request(:get, /api\.screenshotmachine\.com.*/).
-          to_return(
-            :status => 200,  
-            :headers => { 'x-screenshotmachine-response' => 'no_credits' } 
+    context 'when requesting with no credits left' do
+      it 'should raise an exception' do
+        stub_request(:get, /api\.screenshotmachine\.com.*/)
+          .to_return(
+            status: 200,
+            headers: { 'x-screenshotmachine-response' => 'no_credits' }
           )
-        expect{ generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::NoCredits)
+        expect { generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::NoCredits)
       end
     end
 
-    context "when screenshotmachine returns a system_error" do
-      it "should raise an exception" do
-        stub_request(:get, /api\.screenshotmachine\.com.*/).
-          to_return(
-            :status => 200,  
-            :headers => { 'x-screenshotmachine-response' => 'system_error' } 
+    context 'when screenshotmachine returns a system_error' do
+      it 'should raise an exception' do
+        stub_request(:get, /api\.screenshotmachine\.com.*/)
+          .to_return(
+            status: 200,
+            headers: { 'x-screenshotmachine-response' => 'system_error' }
           )
-        expect{ generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::SystemError)
+        expect { generator.screenshot }.to raise_error(ScreenshotMachine::Exceptions::SystemError)
       end
     end
   end

--- a/spec/screenshot_machine_spec.rb
+++ b/spec/screenshot_machine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe ScreenshotMachine do
@@ -5,92 +7,91 @@ describe ScreenshotMachine do
     ScreenshotMachine.reset
   end
 
-  describe ".new" do
-    it "is a ScreenshotMachine::Generator" do
-      expect(ScreenshotMachine.new("")).to be_a ScreenshotMachine::Generator
+  describe '.new' do
+    it 'is a ScreenshotMachine::Generator' do
+      expect(ScreenshotMachine.new('')).to be_a ScreenshotMachine::Generator
     end
   end
 
-  describe ".size" do
-    it "returns the default size" do
+  describe '.size' do
+    it 'returns the default size' do
       expect(ScreenshotMachine.size).to eq(ScreenshotMachine::Configuration::DEFAULT_SIZE)
     end
   end
 
-  describe ".size=" do
-    it "sets the size" do
+  describe '.size=' do
+    it 'sets the size' do
       ScreenshotMachine.size = 'X'
       expect(ScreenshotMachine.size).to eq('X')
     end
   end
 
-  describe ".format" do
-    it "returns the default format" do
+  describe '.format' do
+    it 'returns the default format' do
       expect(ScreenshotMachine.format).to eq(ScreenshotMachine::Configuration::DEFAULT_FORMAT)
     end
   end
 
-  describe ".format=" do
-    it "sets the format" do
+  describe '.format=' do
+    it 'sets the format' do
       ScreenshotMachine.format = 'PNG'
       expect(ScreenshotMachine.format).to eq('PNG')
     end
   end
 
-
-  describe ".cacheLimit" do
-    it "returns the default cacheLimit" do
+  describe '.cacheLimit' do
+    it 'returns the default cacheLimit' do
       expect(ScreenshotMachine.cacheLimit).to eq(ScreenshotMachine::Configuration::DEFAULT_CACHELIMIT)
     end
   end
 
-  describe ".cacheLimit=" do
-    it "sets the cacheLimit" do
+  describe '.cacheLimit=' do
+    it 'sets the cacheLimit' do
       ScreenshotMachine.cacheLimit = 400
       expect(ScreenshotMachine.cacheLimit).to eq(400)
     end
   end
 
-  describe ".timeout" do
-    it "returns the default timeout" do
+  describe '.timeout' do
+    it 'returns the default timeout' do
       expect(ScreenshotMachine.timeout).to eq(ScreenshotMachine::Configuration::DEFAULT_TIMEOUT)
     end
   end
 
-  describe ".timeout=" do
-    it "sets the timeout" do
+  describe '.timeout=' do
+    it 'sets the timeout' do
       ScreenshotMachine.timeout = 400
       expect(ScreenshotMachine.timeout).to eq(400)
     end
   end
 
-  describe ".url" do
-    it "returns the default url" do
+  describe '.url' do
+    it 'returns the default url' do
       expect(ScreenshotMachine.url).to eq(ScreenshotMachine::Configuration::DEFAULT_URL)
     end
   end
 
-  describe ".url=" do
-    it "sets the url" do
+  describe '.url=' do
+    it 'sets the url' do
       ScreenshotMachine.url = 'http://example.com'
       expect(ScreenshotMachine.url).to eq('http://example.com')
     end
   end
 
-  describe ".key" do
-    it "returns the default key" do
+  describe '.key' do
+    it 'returns the default key' do
       expect(ScreenshotMachine.key).to eq(ScreenshotMachine::Configuration::DEFAULT_KEY)
     end
   end
 
-  describe ".key=" do
-    it "sets the key" do
+  describe '.key=' do
+    it 'sets the key' do
       ScreenshotMachine.key = 'abcdefgh123456'
       expect(ScreenshotMachine.key).to eq('abcdefgh123456')
     end
   end
 
-  describe ".configure" do
+  describe '.configure' do
     ScreenshotMachine::Configuration::VALID_PARAMS_KEYS.each do |key|
       it "sets the #{key}" do
         ScreenshotMachine.configure do |config|
@@ -101,10 +102,9 @@ describe ScreenshotMachine do
     end
   end
 
-  describe ".options" do
-    it "returns the configuration as a hash" do
+  describe '.options' do
+    it 'returns the configuration as a hash' do
       expect(ScreenshotMachine.options).to be_kind_of(Hash)
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 unless ENV['CI']
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
Fix some rubocop issues
This should be compatible with ruby 3.0.3

Tests
![Screenshot 2021-12-07 at 6 10 08 PM](https://user-images.githubusercontent.com/12850489/145074668-22996b6c-b35e-4426-9d12-f761a25d699c.png)
:
